### PR TITLE
Iteration2/switch form views

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ var ownCoverButton = document.querySelector('.make-new-button');
 var saveCoverButton = document.querySelector('.save-cover-button');
 var homeButton = document.querySelector('.home-button');
 var form = document.querySelector('.form-view');
+var completeCoverView = document.querySelector('.home-view');
 
 //// We've provided a few variables below
 var savedCovers = [
@@ -23,25 +24,22 @@ window.addEventListener('load', randomBook); //with event listeners, invoking fu
 randomCoverButton.addEventListener('click', randomBook);
 
 ownCoverButton.addEventListener('click', displayFormView);
-//on click of make own cover buttom:
-
-
 
 
 //// Create your event handlers and other functions here 👇
 
-//assembles random book: image, title, and descriptors for tagline
 function displayFormView() {
-  //hide randomcover
-  //save cover button
-  //make home button appear
-  //show form
+  completeCoverView.classList.add('hidden');//hide randomcover
+  saveCoverButton.classList.add('hidden');  //save cover button
+  homeButton.classList.remove('hidden');//make home button appear
+  form.classList.remove('hidden');//show form
+  randomCoverButton.classList.add('hidden'); //hide random cover button
 }
 
 
 
 
-
+//assembles random book: image, title, and descriptors for tagline
 function randomBook() {
   currentCover = new Cover(covers[getRandomIndex(covers)], titles[getRandomIndex(titles)], descriptors[getRandomIndex(descriptors)], descriptors[getRandomIndex(descriptors)])
   image.src = currentCover.cover;

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,22 @@
 //// Create variables targetting the relevant DOM elements here 👇
 
+// book elements
 var image = document.querySelector('.cover-image');
 var title = document.querySelector('.cover-title');
 var taglineOne = document.querySelector('.tagline-1');
 var taglineTwo = document.querySelector('.tagline-2');
+
+// buttons
 var randomCoverButton = document.querySelector('.random-cover-button');
 var ownCoverButton = document.querySelector('.make-new-button');
 var saveCoverButton = document.querySelector('.save-cover-button');
 var homeButton = document.querySelector('.home-button');
+var viewSavedCoversButton = document.querySelector('.view-saved-button');
+
+// views
 var form = document.querySelector('.form-view');
 var completeCoverView = document.querySelector('.home-view');
+var savedCoversLibrary = document.querySelector('.saved-view')
 
 //// We've provided a few variables below
 var savedCovers = [
@@ -25,6 +32,7 @@ randomCoverButton.addEventListener('click', randomBook);
 
 ownCoverButton.addEventListener('click', displayFormView);
 
+viewSavedCoversButton.addEventListener('click', displaySavedCovers)
 
 //// Create your event handlers and other functions here 👇
 
@@ -36,7 +44,13 @@ function displayFormView() {
   randomCoverButton.classList.add('hidden'); //hide random cover button
 }
 
-
+function displaySavedCovers() {
+  savedCoversLibrary.classList.remove('hidden') // show saved cover section
+  randomCoverButton.classList.add('hidden')//hide show new random cover button
+  saveCoverButton.classList.add('hidden');//hide save cover button
+  homeButton.classList.remove('hidden');//show home button
+  completeCoverView.classList.add('hidden');//hide randomcover
+}
 
 
 //assembles random book: image, title, and descriptors for tagline

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,8 @@ ownCoverButton.addEventListener('click', displayFormView);
 
 viewSavedCoversButton.addEventListener('click', displaySavedCovers)
 
+homeButton.addEventListener('click', displayHomeView)
+
 //// Create your event handlers and other functions here 👇
 
 function displayFormView() {
@@ -50,7 +52,19 @@ function displaySavedCovers() {
   saveCoverButton.classList.add('hidden');//hide save cover button
   homeButton.classList.remove('hidden');//show home button
   completeCoverView.classList.add('hidden');//hide randomcover
+  form.classList.add('hidden'); // hide form
 }
+
+function displayHomeView() {
+  completeCoverView.classList.remove('hidden');//show randomcover
+  randomCoverButton.classList.remove('hidden')//how show new random cover button
+  saveCoverButton.classList.remove('hidden');//show save cover button
+  viewSavedCovers.classList.remove('hidden');  //show view Saved Covers button
+  ownCoverButton.classList.remove('hidden');  //show make your own cover button
+  form.classList.add('hidden');  //hide form
+  savedCoversLibrary.classList.add('hidden');
+  homeButton.classList.add('hidden');
+ }
 
 
 //assembles random book: image, title, and descriptors for tagline

--- a/src/main.js
+++ b/src/main.js
@@ -56,12 +56,12 @@ function displaySavedCovers() {
 }
 
 function displayHomeView() {
+  form.classList.add('hidden');  //hide form
   completeCoverView.classList.remove('hidden');//show randomcover
   randomCoverButton.classList.remove('hidden')//how show new random cover button
   saveCoverButton.classList.remove('hidden');//show save cover button
-  viewSavedCovers.classList.remove('hidden');  //show view Saved Covers button
+  viewSavedCoversButton.classList.remove('hidden');  //show view Saved Covers button
   ownCoverButton.classList.remove('hidden');  //show make your own cover button
-  form.classList.add('hidden');  //hide form
   savedCoversLibrary.classList.add('hidden');
   homeButton.classList.add('hidden');
  }

--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,11 @@ var image = document.querySelector('.cover-image');
 var title = document.querySelector('.cover-title');
 var taglineOne = document.querySelector('.tagline-1');
 var taglineTwo = document.querySelector('.tagline-2');
-
-var randomCoverButton = document.querySelector('.random-cover-button')
+var randomCoverButton = document.querySelector('.random-cover-button');
+var ownCoverButton = document.querySelector('.make-new-button');
+var saveCoverButton = document.querySelector('.save-cover-button');
+var homeButton = document.querySelector('.home-button');
+var form = document.querySelector('.form-view');
 
 //// We've provided a few variables below
 var savedCovers = [
@@ -17,11 +20,28 @@ var currentCover;
 //// Add your event listeners here 👇
 window.addEventListener('load', randomBook); //with event listeners, invoking functions do not need the parens
 
-randomCoverButton.addEventListener('click', randomBook)
+randomCoverButton.addEventListener('click', randomBook);
+
+ownCoverButton.addEventListener('click', displayFormView);
+//on click of make own cover buttom:
+
+
+
 
 //// Create your event handlers and other functions here 👇
 
 //assembles random book: image, title, and descriptors for tagline
+function displayFormView() {
+  //hide randomcover
+  //save cover button
+  //make home button appear
+  //show form
+}
+
+
+
+
+
 function randomBook() {
   currentCover = new Cover(covers[getRandomIndex(covers)], titles[getRandomIndex(titles)], descriptors[getRandomIndex(descriptors)], descriptors[getRandomIndex(descriptors)])
   image.src = currentCover.cover;


### PR DESCRIPTION
### What does this PR do?

Adds navigation functionality to all the buttons on the top banners (except Save Cover).

### Is this a feature or refactor?

Feature

### Problems Encountered & Resulting Solutions 

Home button was not initially hiding when navigating back to the home view. Issue was due to a typo that resulted in an undefined variable. Issue has been fixed.

### Where should the reviewer start?

Added new functions for navigation functionality at lines 41, 49 and 58. Also added new variables targeting additional querySelectors and added new Event listeners.

### How should this be tested?

Open index.html on browser - click on 'View Saved Covers', 'Make your own Cover' and 'Home' in different orders to verify all views load correctly. Check Chrome dev tools for any error messages printed to console.

### Steps To Take

Move on to iteration 3 - add functionality to 'New Cover' form.
