### PR TITLE
Fix bug causing saved covers library to appear on form view

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -76,6 +76,7 @@ function displayFormView() {
   homeButton.classList.remove('hidden'); //make home button appear
   form.classList.remove('hidden'); //show form
   randomCoverButton.classList.add('hidden'); //hide random cover button
+  savedCoversLibrary.classList.add('hidden')
 }
 
 function displaySavedCovers() {


### PR DESCRIPTION
### What does this PR do?

PR fixes a minor bug we encountered where the saved covers library remains visible when the user navigates from Saved Covers view to Form view.

### Is this a feature or refactor?

Refactor

### Problems Encountered & Resulting Solutions  >State any problems encountered >Describe your code changes in detail for reviewers.

None. simple fix

### Where should the reviewer start?>What file(s) and line(s) are where changes are made?

Line 79

### How should this be tested?>What steps need to be taken to confirm functionality? 

Open index.html in browser, save multiple random covers and then navigate from View Saved Covers to Make your Own Cover. Verify that the saved covers library is no longer visible.

### Steps To Take>Any questions and possible steps moving forward.

None.